### PR TITLE
Removed nonlinearity from final layer

### DIFF
--- a/pseudo_backprop/network.py
+++ b/pseudo_backprop/network.py
@@ -80,9 +80,10 @@ class FullyConnectedNetwork(torch.nn.Module):
 
         # make the operations
         self.operations_list = []
-        for synapse in self.synapses:
+        for synapse in self.synapses[:-1]:
             self.operations_list.append(synapse)
             self.operations_list.append(torch.nn.ReLU(inplace=True))
+        self.operations_list.append(self.synapses[-1])
         self.operations = torch.nn.Sequential(*self.operations_list)
 
     @classmethod


### PR DESCRIPTION
This fixes nets getting stuck for all models.

Reason: a ReLu on the final layer means that the gradient is 0 if the input to the final layer is negative. Therefore, nets do not learn on average 50% of the time.